### PR TITLE
Added py-ubjson to dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ On Ubuntu, you will need to install the following dependencies:
     sudo apt-get install python-pip
     sudo pip install --upgrade pip
     sudo pip install pycrypto
+    sudo pip install py-ubjson
 
 On CentOS, you will need to install the following dependencies:
 
@@ -45,6 +46,7 @@ On CentOS, you will need to install the following dependencies:
     sudo yum install python-devel
     sudo yum groupinstall "Development tools"
     sudo pip install pycrypto
+    sudo pip install py-ubjson
 
 
 MultiChain Compatibility


### PR DESCRIPTION
Added py-ubjson to the dependencies list, because running `:~/multichain-explorer$ python -m Mce.abe --config chainName.conf --commit-bytes 100000 --no-serve` causes this: `ImportError: No module named ubjson`